### PR TITLE
Scan UTF-32 tracked secrets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-13
 
+- Extended tracked-secret scanning to BOM-marked UTF-32 little-endian and
+  big-endian text before the overlapping UTF-16 BOM checks.
+- Added self-tests for UTF-32 credential detection, byte-order handling, and
+  malformed-input boundaries.
 - Extended tracked-secret scanning to BOM-marked UTF-16 little-endian and
   big-endian text while continuing to skip unrecognized binary data.
 - Supplied both required greeting-message inputs to each event-scoped

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ When the required SDK or runtime is unavailable, use static checks and source re
   HTTP archive captures.
 - Packet captures, trace files, Wrangler local secrets, PEM files, and key files
   are also ignored. The checker scans every tracked UTF-8 text file plus
-  BOM-marked UTF-16 little-endian and big-endian text for real-looking Twilio
-  SIDs, token/phone assignments, and private keys. Unrecognized binary data
-  remains skipped. Token and phone checks cover shell exports plus dotenv,
-  YAML, and JSON assignments.
+  BOM-marked UTF-16 and UTF-32 little-endian and big-endian text for
+  real-looking Twilio SIDs, token/phone assignments, and private keys.
+  Unrecognized binary data remains skipped. Token and phone checks cover shell
+  exports plus dotenv, YAML, and JSON assignments.
 - `.env.example` documents expected Twilio variable names with empty values and
   keeps live sends disabled by default, including a placeholder body for future
   message smoke tests and an `info` log-level default. Each placeholder
@@ -126,6 +126,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   YAML, and JSON credential-assignment coverage.
 - See `docs/plans/2026-06-13-utf16-tracked-secret-scan.md` for the UTF-16
   tracked-text encoding boundary.
+- See `docs/plans/2026-06-13-utf32-tracked-secret-scan.md` for the UTF-32 BOM
+  ordering and tracked-text encoding boundary.
 - The pinned first-interaction v3.1.0 implementation reads both greeting
   message inputs on every supported event; each event-scoped job therefore
   supplies both non-secret messages while retaining its narrow write scope.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,9 +32,9 @@ Helpful reports include:
   they can contain credentials, account identifiers, request URLs, or payloads.
 - Packet captures, trace files, `.dev.vars`, PEM files, and private key files
   should remain ignored. The repository gate scans all tracked UTF-8 text and
-  BOM-marked UTF-16 little-endian and big-endian text for real-looking Twilio
-  SIDs, populated token/phone assignments, and private-key blocks while
-  leaving unrecognized binary data uninterpreted.
+  BOM-marked UTF-16 and UTF-32 little-endian and big-endian text for
+  real-looking Twilio SIDs, populated token/phone assignments, and private-key
+  blocks while leaving unrecognized binary data uninterpreted.
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 
 ## Service and API Notes

--- a/VISION.md
+++ b/VISION.md
@@ -21,6 +21,7 @@ Priority:
 - Ignore packet captures, traces, local Worker secrets, and key material
 - Scan all tracked text for real-looking Twilio identifiers and secrets
 - Scan BOM-marked UTF-16 tracked text without treating arbitrary binary as text
+- Scan BOM-marked UTF-32 tracked text before overlapping UTF-16 BOM prefixes
 - Scan common shell, dotenv, YAML, and JSON secret assignment syntaxes
 - Ignore local OS and IDE metadata
 - Keep environment examples placeholder-only and live sends disabled

--- a/docs/plans/2026-06-13-utf32-tracked-secret-scan.md
+++ b/docs/plans/2026-06-13-utf32-tracked-secret-scan.md
@@ -1,0 +1,64 @@
+---
+title: "fix: Scan UTF-32 tracked text for Twilio secrets"
+date: 2026-06-13
+---
+
+# Scan UTF-32 Tracked Text for Twilio Secrets
+
+## Status: In Progress
+
+## Context
+
+The tracked-file scanner recognizes BOM-marked UTF-16, but UTF-32 little-endian
+begins with the UTF-16 little-endian BOM prefix and is therefore misdecoded.
+UTF-32 big-endian is treated as binary. Both cases can hide otherwise detected
+Twilio credentials in tracked text.
+
+## Requirements
+
+- R1. Decode BOM-marked UTF-32 little-endian and big-endian tracked text before
+  checking UTF-16 BOMs.
+- R2. Apply the existing Twilio SID, auth-token, phone-number, and private-key
+  patterns to successfully decoded UTF-32 text.
+- R3. Keep malformed UTF-32 and arbitrary NUL-containing binary skipped rather
+  than guessing encodings.
+- R4. Preserve UTF-8 and UTF-16 behavior through one shared decoder.
+- R5. Add self-tests for both UTF-32 byte orders, malformed UTF-32, BOM-ordering
+  precedence, and ordinary binary.
+- R6. Register a completed plan and update security and operator guidance.
+- R7. Mutation tests must reject removed UTF-32 support, reversed BOM ordering,
+  missing byte-order coverage, and weakened malformed-input handling.
+
+## Scope Boundaries
+
+- Do not attempt heuristic legacy-encoding detection, scan untracked files, or
+  inspect repository history.
+- Do not add dependencies or introduce real credential fixtures.
+- Do not reinterpret arbitrary binary as text.
+
+## Implementation Units
+
+### U1. Extend the shared tracked-text decoder
+
+- **Files:** `scripts/check_repository_contracts.py`
+- Recognize the four-byte UTF-32 BOMs before the overlapping UTF-16 prefixes.
+
+### U2. Add encoding-boundary self-tests
+
+- **Files:** `scripts/check_repository_contracts.py`
+- Build synthetic token assignments at runtime and verify detection in both
+  byte orders without checking secret material into the repository.
+
+### U3. Preserve repository contracts and guidance
+
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Document explicit BOM support and the remaining binary/history boundary.
+
+## Verification
+
+- Focused encoding self-test and full `make check`
+- External-directory and space-containing-path `make check`
+- Hostile mutations for BOM support, ordering, byte orders, malformed input,
+  and plan completion
+- Workflow YAML, Python syntax, SVG XML, `git diff --check`, generated-artifact,
+  and focused secret review

--- a/docs/plans/2026-06-13-utf32-tracked-secret-scan.md
+++ b/docs/plans/2026-06-13-utf32-tracked-secret-scan.md
@@ -5,7 +5,7 @@ date: 2026-06-13
 
 # Scan UTF-32 Tracked Text for Twilio Secrets
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -56,9 +56,13 @@ Twilio credentials in tracked text.
 
 ## Verification
 
-- Focused encoding self-test and full `make check`
-- External-directory and space-containing-path `make check`
-- Hostile mutations for BOM support, ordering, byte orders, malformed input,
-  and plan completion
+- `python3 -c 'import scripts.check_repository_contracts as c;
+  c.check_secret_pattern_encodings()'` passed UTF-16 LE/BE, UTF-32 LE/BE,
+  malformed UTF-16/UTF-32, and arbitrary-binary boundaries.
+- Full local, external-directory, and space-containing-path `make check` runs
+  passed all nine repository contract groups.
+- Eight hostile mutations covering removed UTF-32 support, the wrong codec,
+  missing LE/BE BOM handling, accepted malformed input, reduced byte-order
+  fixtures, and stale plan status were rejected.
 - Workflow YAML, Python syntax, SVG XML, `git diff --check`, generated-artifact,
-  and focused secret review
+  and focused secret reviews are included in final validation.

--- a/scripts/check_repository_contracts.py
+++ b/scripts/check_repository_contracts.py
@@ -19,6 +19,7 @@ WORKFLOW_HARDENING_PLAN = DOCS_PLANS / "2026-06-10-workflow-hardening-and-ci.md"
 TRACKED_SECRET_SCAN_PLAN = DOCS_PLANS / "2026-06-10-tracked-secret-scan.md"
 SECRET_SYNTAX_PLAN = DOCS_PLANS / "2026-06-10-secret-assignment-syntaxes.md"
 UTF16_SECRET_SCAN_PLAN = DOCS_PLANS / "2026-06-13-utf16-tracked-secret-scan.md"
+UTF32_SECRET_SCAN_PLAN = DOCS_PLANS / "2026-06-13-utf32-tracked-secret-scan.md"
 
 TRACKED_SECRET_PATTERNS = [
     (re.compile(r"(?<![0-9A-Za-z])(AC|SK|SM|CA)[0-9a-fA-F]{32}(?![0-9A-Za-z])"), "Twilio SID"),
@@ -64,6 +65,11 @@ def env_entries(env_text):
 
 
 def decode_tracked_text(data):
+    if data.startswith((b"\xff\xfe\x00\x00", b"\x00\x00\xfe\xff")):
+        try:
+            return data.decode("utf-32")
+        except UnicodeDecodeError:
+            return None
     if data.startswith((b"\xff\xfe", b"\xfe\xff")):
         try:
             return data.decode("utf-16")
@@ -249,19 +255,29 @@ def check_secret_pattern_syntaxes():
 
 def check_secret_pattern_encodings():
     token_assignment = "TWILIO_AUTH_TOKEN: " + "0123456789abcdef" * 2
-    encoded_fixtures = [
-        b"\xff\xfe" + token_assignment.encode("utf-16-le"),
-        b"\xfe\xff" + token_assignment.encode("utf-16-be"),
-    ]
-    for fixture in encoded_fixtures:
+    encoded_fixtures = {
+        "UTF-16 LE": b"\xff\xfe" + token_assignment.encode("utf-16-le"),
+        "UTF-16 BE": b"\xfe\xff" + token_assignment.encode("utf-16-be"),
+        "UTF-32 LE": b"\xff\xfe\x00\x00" + token_assignment.encode("utf-32-le"),
+        "UTF-32 BE": b"\x00\x00\xfe\xff" + token_assignment.encode("utf-32-be"),
+    }
+    require(
+        set(encoded_fixtures) == {"UTF-16 LE", "UTF-16 BE", "UTF-32 LE", "UTF-32 BE"},
+        "encoding fixtures must cover both byte orders for UTF-16 and UTF-32",
+    )
+    for encoding, fixture in encoded_fixtures.items():
         decoded = decode_tracked_text(fixture)
-        require(decoded == token_assignment, "UTF-16 tracked text must decode consistently")
+        require(decoded == token_assignment, f"{encoding} tracked text must decode consistently")
         require(
             any(pattern.search(decoded) for pattern, _ in TRACKED_SECRET_PATTERNS),
-            "tracked-secret patterns must reject UTF-16 credential assignments",
+            f"tracked-secret patterns must reject {encoding} credential assignments",
         )
     require(decode_tracked_text(b"\x00\x01\x02\x03") is None, "binary data must remain skipped")
     require(decode_tracked_text(b"\xff\xfe\x00") is None, "malformed UTF-16 must remain skipped")
+    require(
+        decode_tracked_text(b"\xff\xfe\x00\x00\x00") is None,
+        "malformed UTF-32 must remain skipped",
+    )
 
 
 def check_greetings_workflow():
@@ -357,6 +373,10 @@ def check_docs_plans():
     require(
         UTF16_SECRET_SCAN_PLAN in plans,
         f"{UTF16_SECRET_SCAN_PLAN.relative_to(ROOT)} must be present",
+    )
+    require(
+        UTF32_SECRET_SCAN_PLAN in plans,
+        f"{UTF32_SECRET_SCAN_PLAN.relative_to(ROOT)} must be present",
     )
 
     for plan in plans:


### PR DESCRIPTION
## Summary

- decode BOM-marked UTF-32 little-endian and big-endian tracked text before overlapping UTF-16 prefixes
- apply the existing Twilio SID, token, phone, and private-key patterns to decoded UTF-32 content
- preserve skip behavior for malformed encodings and arbitrary NUL-containing binary

## Baseline

- the current-tree scanner did not decode BOM-marked UTF-32 tracked text before applying secret patterns
- overlapping UTF-16 prefixes required explicit byte-order handling to avoid misclassification

## Improvements

- enforce exact UTF-16/UTF-32 byte-order fixture coverage in the repository contracts
- Compound Engineering review found no actionable correctness, security, testing, maintainability, or project-standards issues

## Validation

- focused encoding self-test passed UTF-16 LE/BE, UTF-32 LE/BE, malformed encoding, and binary boundaries
- local, external-directory, and space-containing-path `make check` passed all nine contract groups
- eight hostile mutations rejected
- workflow YAML, Python syntax, SVG XML, diff, generated-artifact, and focused secret checks passed
- exact-head verification jobs passed on Python 3.10, 3.12, and 3.14

## Risk

- BOM-less legacy encodings, untracked files, and repository history remain outside this current-tree scanner by design
- the ancillary `greet-pull-request` job currently fails because `pull_request_target` executes `master`'s greeting workflow, which omits the `issue_message` input now required by `actions/first-interaction`; the stacked PR #4 branch already contains that fix
- this is a stacked pull request based on PR #4 (`lfg/twilio-utf16-secret-scan-20260613`), so the predecessor workflow fix must reach the default branch before this greeting job can pass on rerun

## Follow-Ups

This PR builds on `lfg/twilio-utf16-secret-scan-20260613` (PR #4). Review and merge the stack in order, then rerun the failed greeting workflow after the predecessor fix is present on the default branch.
