### PR TITLE
fix: supply required default greeting inputs

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         repo_token: ${{ github.token }}
         issue_message: 'Ahoy!'
+        pr_message: 'Ahoy!'
 
   greet-pull-request:
     if: github.event_name == 'pull_request_target'
@@ -37,4 +38,5 @@ jobs:
     - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
       with:
         repo_token: ${{ github.token }}
+        issue_message: 'Ahoy!'
         pr_message: 'Ahoy!'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Supplied both required first-interaction message inputs to each event-scoped
+  default-branch greeting job and added count-sensitive regression contracts.
+
 ## 2026-06-10
 
 - Extended tracked Twilio secret detection across shell exports, dotenv, YAML,

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build check lint test verify
 
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 PYTHON ?= python3
 
 lint:

--- a/docs/plans/2026-06-14-default-context-greeting-inputs.md
+++ b/docs/plans/2026-06-14-default-context-greeting-inputs.md
@@ -1,0 +1,39 @@
+# Default-Context Greeting Inputs
+
+Status: Planned
+
+## Problem
+
+The pinned `actions/first-interaction` v3.1.0 action reads both
+`issue_message` and `pr_message` on every invocation. The default-branch
+pull-request greeting supplies only `pr_message`, so every newly opened pull
+request fails in the privileged `pull_request_target` workflow before it can
+post the greeting.
+
+## Requirements
+
+1. Supply both required message inputs to both event-scoped greeting jobs.
+2. Preserve the immutable action pin, repository token, fixed runner, bounded
+   timeout, event filters, and least-privilege job permissions.
+3. Strengthen the dependency-free checker so each exact message input must
+   appear once per action invocation, not merely somewhere in the workflow.
+4. Reject missing issue or pull-request inputs in either job through focused
+   mutations.
+5. Land the narrow fix on the default branch so future
+   `pull_request_target` runs load the corrected workflow definition.
+
+## Verification
+
+- Compile and run the dependency-free checker.
+- Run local and external-directory `make check` gates.
+- Reject four focused per-job missing-input mutations.
+- Parse workflow YAML and audit the exact diff, artifacts, whitespace, and
+  changed-line credentials.
+- After the normal default-branch push, rerun the existing failed Greetings
+  workflow and verify the pull-request job succeeds at the unchanged PR head.
+
+## Scope Boundaries
+
+- Do not add checkout, command execution, broader permissions, mutable action
+  tags, Twilio credentials, or runtime behavior.
+- Do not merge or close any pull request without explicit owner authorization.

--- a/docs/plans/2026-06-14-default-context-greeting-inputs.md
+++ b/docs/plans/2026-06-14-default-context-greeting-inputs.md
@@ -1,6 +1,6 @@
 # Default-Context Greeting Inputs
 
-Status: Planned
+Status: Completed
 
 ## Problem
 
@@ -37,3 +37,22 @@ post the greeting.
 - Do not add checkout, command execution, broader permissions, mutable action
   tags, Twilio credentials, or runtime behavior.
 - Do not merge or close any pull request without explicit owner authorization.
+
+## Work Completed
+
+- Supplied both required message inputs to both event-scoped pinned action
+  invocations on the default branch.
+- Strengthened the dependency-free contracts to require two repository-token,
+  issue-message, and pull-request-message inputs and registered this completed
+  plan.
+
+## Verification Results
+
+- Python compilation plus local and external-directory `make check` passed all
+  eight repository contract groups.
+- Four focused mutations removing either required input from either greeting
+  job were rejected.
+- Workflow YAML, whitespace, explicit-artifact, exact-diff, and changed-line
+  credential audits passed.
+- Default-branch delivery and hosted greeting evidence will be appended after
+  the normal push because `pull_request_target` reads this default-branch file.

--- a/docs/plans/2026-06-14-default-context-greeting-inputs.md
+++ b/docs/plans/2026-06-14-default-context-greeting-inputs.md
@@ -54,5 +54,8 @@ post the greeting.
   job were rejected.
 - Workflow YAML, whitespace, explicit-artifact, exact-diff, and changed-line
   credential audits passed.
-- Default-branch delivery and hosted greeting evidence will be appended after
-  the normal push because `pull_request_target` reads this default-branch file.
+- A normal fast-forward push to `master` was rejected by branch protection
+  because the three required verification contexts must run through a pull
+  request. The hotfix is therefore delivered on a review branch; its own
+  `pull_request_target` greeting remains blocked by the older default-branch
+  workflow until an authorized merge updates `master`.

--- a/docs/plans/2026-06-14-default-context-greeting-inputs.md
+++ b/docs/plans/2026-06-14-default-context-greeting-inputs.md
@@ -19,7 +19,9 @@ post the greeting.
    appear once per action invocation, not merely somewhere in the workflow.
 4. Reject missing issue or pull-request inputs in either job through focused
    mutations.
-5. Land the narrow fix on the default branch so future
+5. Protect the Makefile-derived repository root from command-line overrides so
+   external validation cannot be redirected away from the reviewed checkout.
+6. Land the narrow fix on the default branch so future
    `pull_request_target` runs load the corrected workflow definition.
 
 ## Verification
@@ -45,11 +47,15 @@ post the greeting.
 - Strengthened the dependency-free contracts to require two repository-token,
   issue-message, and pull-request-message inputs and registered this completed
   plan.
+- Protected the Makefile-derived repository root and required that exact
+  definition in the portable checker.
 
 ## Verification Results
 
 - Python compilation plus local and external-directory `make check` passed all
   eight repository contract groups.
+- An external-directory `make check` with a hostile `ROOT=/nonexistent`
+  override passed against the intended checkout.
 - Four focused mutations removing either required input from either greeting
   job were rejected.
 - Workflow YAML, whitespace, explicit-artifact, exact-diff, and changed-line

--- a/scripts/check_repository_contracts.py
+++ b/scripts/check_repository_contracts.py
@@ -18,6 +18,7 @@ LOCAL_METADATA_IGNORE_PLAN = DOCS_PLANS / "2026-06-09-local-metadata-ignore.md"
 WORKFLOW_HARDENING_PLAN = DOCS_PLANS / "2026-06-10-workflow-hardening-and-ci.md"
 TRACKED_SECRET_SCAN_PLAN = DOCS_PLANS / "2026-06-10-tracked-secret-scan.md"
 SECRET_SYNTAX_PLAN = DOCS_PLANS / "2026-06-10-secret-assignment-syntaxes.md"
+DEFAULT_GREETING_INPUTS_PLAN = DOCS_PLANS / "2026-06-14-default-context-greeting-inputs.md"
 
 TRACKED_SECRET_PATTERNS = [
     (re.compile(r"(?<![0-9A-Za-z])(AC|SK|SM|CA)[0-9a-fA-F]{32}(?![0-9A-Za-z])"), "Twilio SID"),
@@ -248,10 +249,10 @@ def check_greetings_workflow():
     require("ubuntu-latest" not in workflow, "greetings workflow must not use a floating runner")
     require(workflow.count("runs-on: ubuntu-24.04") == 2, "both greeting jobs must use Ubuntu 24.04")
     require(workflow.count("actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0") == 2, "both greeting jobs must use the annotated first-interaction pin")
-    require("repo_token: ${{ github.token }}" in workflow, "greetings workflow must use the repository token")
+    require(workflow.count("repo_token: ${{ github.token }}") == 2, "both greeting jobs must use the repository token")
     require("TWILIO_" not in workflow, "placeholder workflow must not reference Twilio credentials")
-    require("issue_message:" in workflow, "greetings workflow must keep issue greeting explicit")
-    require("pr_message:" in workflow, "greetings workflow must keep pull-request greeting explicit")
+    require(workflow.count("issue_message: 'Ahoy!'") == 2, "both greeting jobs must supply the required issue message")
+    require(workflow.count("pr_message: 'Ahoy!'") == 2, "both greeting jobs must supply the required pull-request message")
     require("@v" not in workflow, "greetings workflow action must use an immutable commit")
     require("actions/checkout" not in workflow, "pull_request_target workflow must not check out contributor code")
     require(not re.search(r"^\s*run:", workflow, re.MULTILINE), "pull_request_target workflow must not execute commands")
@@ -324,6 +325,10 @@ def check_docs_plans():
     require(
         SECRET_SYNTAX_PLAN in plans,
         f"{SECRET_SYNTAX_PLAN.relative_to(ROOT)} must be present",
+    )
+    require(
+        DEFAULT_GREETING_INPUTS_PLAN in plans,
+        f"{DEFAULT_GREETING_INPUTS_PLAN.relative_to(ROOT)} must be present",
     )
 
     for plan in plans:

--- a/scripts/check_repository_contracts.py
+++ b/scripts/check_repository_contracts.py
@@ -283,9 +283,14 @@ def check_hosted_verification():
     require("ubuntu-latest" not in workflow, "hosted verification must not use a floating runner")
     require("@v" not in workflow, "hosted verification actions must use immutable commits")
     makefile = read_text("Makefile")
+    makefile_lines = set(makefile.splitlines())
     require(
-        "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile,
-        "Makefile must resolve the repository root from its own location",
+        "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile_lines,
+        "Makefile must protect the repository root derived from its own location",
+    )
+    require(
+        "PYTHON ?= python3" in makefile_lines,
+        "Makefile must preserve the Python command override",
     )
     require(
         '$(PYTHON) "$(ROOT)/scripts/check_repository_contracts.py"' in makefile,


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and merge state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #7 remains merged at head `9df4e3ea06efa277af44996d8a932e7e9231d119`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary

New pull requests can receive the pinned first-interaction greeting after this branch reaches `master`, and external verification can no longer be redirected away from the reviewed checkout with a hostile `ROOT=` override.

The default-branch workflow currently omits one required message input from each event-scoped job. Because `pull_request_target` loads the workflow from `master`, this PR's greeting check remains circularly blocked until an authorized merge installs the corrected definition.

## Improvements

- Supply both `issue_message` and `pr_message` to both pinned greeting invocations.
- Preserve event filters, immutable action pinning, fixed runners, bounded timeouts, repository-token usage, and least-privilege job permissions.
- Require exact per-job message counts in the dependency-free contracts.
- Protect the Makefile-derived repository root from command-line overrides and enforce that definition in the same portable checker.

## Validation

- Repository-root `make check`: all eight contract groups passed.
- External-directory `make check ROOT=/nonexistent`: all eight contract groups passed against the intended checkout.
- Workflow YAML parsed with exactly `repo_token`, `issue_message`, and `pr_message` in both jobs.
- `git diff --check`, generated-artifact inspection, and changed-line credential scans passed.
- Required Python 3.10, 3.12, and 3.14 checks and CodeQL validate the branch; the greeting job cannot validate its own default-context fix before delivery to `master`.

## Risk

The branch must be merged through the protected pull-request path before the trusted greeting workflow can use this fix. Do not weaken branch protection, remove the greeting check, or execute contributor code in `pull_request_target` to bypass that boundary.

## Follow-Up

After authorized delivery to `master`, open a new issue or pull request and verify that the corresponding greeting job succeeds.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

