### PR TITLE
build: harden make verification authority

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run repository verification
-        run: make check
+        run: ./scripts/run-make.sh check

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+- Hardened `make check` against Make-syntax Python expansion, caller shell and
+  Makefile identity replacement, execution-skipping flags, and startup-file
+  configuration while preserving literal multiword Python overrides.
+
 ## 2026-06-19
 
 - Bounded tracked secret scans, rejected symlinks and special entries, and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+- Added a physical-root `check|lint` wrapper for hosted and contributor
+  verification, clearing all five GNU Make control variables before Make starts
+  and covering dry-run, ignore-errors, startup-file, `--eval`, and extra-`-f`
+  authority paths.
 - Hardened `make check` against Make-syntax Python expansion, caller shell and
   Makefile identity replacement, execution-skipping flags, and startup-file
   configuration while preserving literal multiword Python overrides.

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,74 @@
-.PHONY: build check lint test verify
+.DEFAULT_GOAL := check
+.PHONY: __repository-make-authority build check lint root-test test verify
 
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+PUBLIC_TARGETS := build check lint root-test test verify
+
 PYTHON ?= python3
+override PYTHON := $(value PYTHON)
+export PYTHON
+override REPOSITORY_MAKE_DOLLAR := $$
+override REPOSITORY_MAKE_OPEN := (
+ifneq ($(findstring $(REPOSITORY_MAKE_DOLLAR)$(REPOSITORY_MAKE_OPEN),$(value PYTHON)),)
+$(error PYTHON must be literal command text, not Make syntax)
+endif
+override SHELL := /bin/sh
+override .SHELLFLAGS := -c
+
+ifneq ($(filter command line,$(origin MAKEFLAGS)),)
+$(error MAKEFLAGS must not be overridden for repository verification)
+endif
+override REPOSITORY_MAKE_FIRST_FLAGS := $(firstword $(MAKEFLAGS))
+ifneq ($(filter -%,$(REPOSITORY_MAKE_FIRST_FLAGS)),)
+override REPOSITORY_MAKE_FIRST_FLAGS :=
+endif
+override REPOSITORY_MAKE_SHORT_FLAGS := $(REPOSITORY_MAKE_FIRST_FLAGS) $(filter-out --%,$(filter -%,$(MAKEFLAGS)))
+ifneq ($(findstring n,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring t,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring q,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring i,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(filter --just-print --dry-run --recon --touch --question --ignore-errors,$(MAKEFLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override REPOSITORY_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+override REPOSITORY_ROOT := $(abspath $(dir $(REPOSITORY_MAKEFILE)))
+override ROOT := $(REPOSITORY_ROOT)
+export ROOT
+
+$(PUBLIC_TARGETS): override SHELL := /bin/sh
+$(PUBLIC_TARGETS): override .SHELLFLAGS := -c
+$(PUBLIC_TARGETS): override ROOT := $(REPOSITORY_ROOT)
+$(PUBLIC_TARGETS): __repository-make-authority
+
+__repository-make-authority:
+	@:
 
 lint:
-	$(PYTHON) "$(ROOT)/scripts/check_repository_contracts.py"
+	$$PYTHON "$$ROOT/scripts/check_repository_contracts.py"
 
 test: lint
-	$(PYTHON) -m unittest discover -v -s "$(ROOT)/tests" -p "test_*.py"
-	$(PYTHON) "$(ROOT)/scripts/test_greetings_runtime.py"
+	$$PYTHON -m unittest discover -v -s "$$ROOT/tests" -p "test_*.py"
+	$$PYTHON "$$ROOT/scripts/test_greetings_runtime.py"
 
 build: lint
 
 verify: lint test build
 
-check: verify
+root-test:
+	$$PYTHON "$$ROOT/scripts/test_makefile_authority.py"
+
+check: root-test verify

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 
 - No single runtime entry point was identified. Start by reading the source files and manifests listed above.
 - Run `make check` to check the placeholder documentation and GitHub workflow contract.
+- When invoked with the checked-in Makefile alone, verification protects its
+  repository root and shell, preserves literal multiword Python overrides, and
+  rejects skipped-mode flags, populated `MAKEFILES`, and `MAKEFILE_LIST`
+  replacement. Startup files and later caller `-f` files remain outside the
+  documented GNU Make trust boundary.
 - Copy `.env.example` to `.env` only for local experiments. Keep the placeholder
   values empty until a real mock or sandbox test harness exists.
 
@@ -132,6 +137,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   ordering and tracked-text encoding boundary.
 - See `docs/plans/2026-06-19-deep-review-boundaries.md` for bounded scanning,
   runtime-free placeholder enforcement, and current workflow pins.
+- See `docs/plans/2026-06-21-make-authority-hardening.md` for Python command,
+  shell, flag, startup-file, and Makefile-identity authority checks.
 - The pinned first-interaction v3.1.0 implementation reads both greeting
   message inputs on every supported event; each event-scoped job therefore
   supplies both non-secret messages while retaining its narrow write scope.

--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 ## Running or Using the Project
 
 - No single runtime entry point was identified. Start by reading the source files and manifests listed above.
-- Run `make check` to check the placeholder documentation and GitHub workflow contract.
-- When invoked with the checked-in Makefile alone, verification protects its
-  repository root and shell, preserves literal multiword Python overrides, and
-  rejects skipped-mode flags, populated `MAKEFILES`, and `MAKEFILE_LIST`
-  replacement. Startup files and later caller `-f` files remain outside the
-  documented GNU Make trust boundary.
+- Run `./scripts/run-make.sh check` to check the placeholder documentation and
+  GitHub workflow contract through the reviewed repository entrypoint.
+- The wrapper resolves its physical checkout, accepts only `check` or `lint`,
+  clears `MAKEFILES`, `MAKEFLAGS`, `MFLAGS`, `MAKEOVERRIDES`, and
+  `GNUMAKEFLAGS`, and invokes the physical Makefile with fixed system tools.
+  Raw GNU Make startup files, `--eval`, and earlier or later caller `-f` files
+  execute before or outside repository policy and are caller authority.
+- Literal `PYTHON` command text and executable lookup through `PATH` remain
+  caller authority for local use. Make-syntax Python values are rejected.
 - Copy `.env.example` to `.env` only for local experiments. Keep the placeholder
   values empty until a real mock or sandbox test harness exists.
 
@@ -59,7 +62,8 @@ adding runtime code. In particular, live calls and messages must remain opt-in.
 
 ## Testing and Verification
 
-- `make check`
+- `./scripts/run-make.sh check` (the supported hosted and contributor gate)
+- `make check` (direct Make invocation for trusted local callers only)
 - GitHub Actions runs the same contracts on Python 3.10, 3.12, and 3.14 with
   read-only repository contents permissions, Ubuntu 24.04, and immutable action
   pins; checkout credentials are not persisted for later steps.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,15 @@ Helpful reports include:
   real-looking Twilio SIDs, populated token/phone assignments, and private-key
   blocks while leaving unrecognized binary data uninterpreted.
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
+- Use `./scripts/run-make.sh check` for repository verification. The wrapper
+  resolves the physical checkout, accepts only the reviewed `check` or `lint`
+  target, clears GNU Make startup and option variables, and invokes the
+  physical Makefile with fixed system tools. Direct GNU Make options,
+  `MAKEFILES`, `--eval`, and additional `-f` files are caller authority before
+  or outside repository policy.
+- Literal `PYTHON` selection and executable lookup through the caller's `PATH`
+  remain intentionally caller-controlled for local toolchain selection. Do not
+  treat verification run under an untrusted interpreter or `PATH` as trusted.
 
 ## Service and API Notes
 

--- a/docs/plans/2026-06-21-make-authority-hardening.md
+++ b/docs/plans/2026-06-21-make-authority-hardening.md
@@ -4,14 +4,16 @@
 
 ## Context
 
-The portable `make check` gate protected its root but still accepted Make-syntax
-Python values, caller shells, execution-skipping flags, startup files, and
-Makefile identity replacement.
+The portable `make check` gate protected its root after parsing, but GNU Make
+could process execution-skipping flags, `--eval`, startup files, and additional
+`-f` files before repository policy ran.
 
 ## Requirements
 
 - Preserve literal, multiword Python command overrides.
 - Reject Make-syntax commands before expansion and keep root/shell authority local.
+- Add a fixed-target physical-root wrapper for hosted and contributor checks.
+- Clear every inherited GNU Make control variable before Make starts.
 - Prove repository and external-directory `make check` behavior.
 - Keep all Twilio credentials unset and make no live provider calls.
 
@@ -19,15 +21,21 @@ Makefile identity replacement.
 
 - Bound root, shell, Python command, flag, startup-file, and Makefile identity authority.
 - Added Python-native adversarial regression coverage to `make check`.
-- Preserved the documented GNU Make startup and later-`-f` trust boundary.
+- Added `scripts/run-make.sh` with byte-preserving bounded symlink resolution,
+  exact `check|lint` target selection, fixed tools, and five-variable Make
+  sanitization.
+- Bound hosted CI to the wrapper and documented direct Make, literal `PYTHON`,
+  and caller `PATH` as explicit local trust boundaries.
 
 ## Verification
 
-- Sanitized repository and external-directory `make check` passed offline.
+- Sanitized repository and external-directory `make check` passed offline
+  through `./scripts/run-make.sh check`.
 - No Twilio credentials, provider endpoints, recipients, or live calls were used.
 
 ## Scope Boundaries
 
-No provider runtime, dependency, credential handling, workflow, publishing, or
-deployment changed. GNU Make startup files can execute during parsing, and
-later caller-supplied `-f` files remain outside authority.
+No provider runtime, dependency, credential handling, publishing, or deployment
+changed. Direct GNU Make startup files, `--eval`, and earlier or later `-f`
+files remain caller authority; hosted CI no longer exposes those channels.
+Literal `PYTHON` and executable lookup through `PATH` remain caller-controlled.

--- a/docs/plans/2026-06-21-make-authority-hardening.md
+++ b/docs/plans/2026-06-21-make-authority-hardening.md
@@ -1,0 +1,33 @@
+# Make Authority Hardening
+
+## Status: Completed
+
+## Context
+
+The portable `make check` gate protected its root but still accepted Make-syntax
+Python values, caller shells, execution-skipping flags, startup files, and
+Makefile identity replacement.
+
+## Requirements
+
+- Preserve literal, multiword Python command overrides.
+- Reject Make-syntax commands before expansion and keep root/shell authority local.
+- Prove repository and external-directory `make check` behavior.
+- Keep all Twilio credentials unset and make no live provider calls.
+
+## Work Completed
+
+- Bound root, shell, Python command, flag, startup-file, and Makefile identity authority.
+- Added Python-native adversarial regression coverage to `make check`.
+- Preserved the documented GNU Make startup and later-`-f` trust boundary.
+
+## Verification
+
+- Sanitized repository and external-directory `make check` passed offline.
+- No Twilio credentials, provider endpoints, recipients, or live calls were used.
+
+## Scope Boundaries
+
+No provider runtime, dependency, credential handling, workflow, publishing, or
+deployment changed. GNU Make startup files can execute during parsing, and
+later caller-supplied `-f` files remain outside authority.

--- a/scripts/check_repository_contracts.py
+++ b/scripts/check_repository_contracts.py
@@ -31,6 +31,7 @@ MAX_TRACKED_TOTAL_BYTES = 16 * 1024 * 1024
 MAX_TRACKED_FILES = 4096
 ALLOWED_SOURCE_PATHS = {
     "scripts/check_repository_contracts.py",
+    "scripts/run-make.sh",
     "scripts/test_greetings_runtime.py",
     "scripts/test_makefile_authority.py",
     "tests/test_repository_contracts.py",
@@ -255,6 +256,7 @@ def check_required_files():
         "docs/readme-overview.svg",
         ".github/workflows/check.yml",
         ".github/workflows/greetings.yml",
+        "scripts/run-make.sh",
         "scripts/test_greetings_runtime.py",
     ]:
         require((ROOT / relative_path).exists(), f"{relative_path} must stay checked in")
@@ -525,12 +527,27 @@ def check_hosted_verification():
         "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
         "persist-credentials: false",
         "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0",
-        "run: make check",
+        "run: ./scripts/run-make.sh check",
     ]:
         require(contract in workflow, f"hosted verification must include {contract!r}")
     require("ubuntu-latest" not in workflow, "hosted verification must not use a floating runner")
     require("@v" not in workflow, "hosted verification actions must use immutable commits")
-    require(workflow.count("run:") == 1, "hosted verification must expose only the reviewed make check command")
+    require("run: make check" not in workflow, "hosted verification must not invoke raw Make")
+    require(workflow.count("run:") == 1, "hosted verification must expose only the reviewed Make wrapper command")
+    wrapper = read_text("scripts/run-make.sh")
+    wrapper_lines = set(wrapper.splitlines())
+    for wrapper_contract in [
+        "#!/bin/sh",
+        "set -eu",
+        "while [ -L \"$SCRIPT_PATH\" ]; do",
+        "  if ! LINK_TARGET_WITH_SENTINEL=$(/usr/bin/readlink -n \"$SCRIPT_PATH\" && printf x); then",
+        "ROOT_DIR=$(CDPATH='' cd -P \"$SCRIPT_DIR/..\" && /bin/pwd -P)",
+        "  check|lint) TARGET=$1 ;;",
+        'exec /usr/bin/env -u MAKEFILES -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES -u GNUMAKEFLAGS /usr/bin/make --no-print-directory -f "$ROOT_DIR/Makefile" "$TARGET"',
+    ]:
+        require(wrapper_contract in wrapper_lines, f"Make wrapper must include {wrapper_contract!r}")
+    require("$@" not in wrapper, "Make wrapper must not forward unrestricted arguments")
+    require("LINK_COUNT=0" in wrapper and '"$LINK_COUNT" -gt 40' in wrapper, "Make wrapper must bound symlink resolution")
     makefile = read_text("Makefile")
     makefile_lines = set(makefile.splitlines())
     require(

--- a/scripts/check_repository_contracts.py
+++ b/scripts/check_repository_contracts.py
@@ -25,12 +25,14 @@ UTF32_SECRET_SCAN_PLAN = DOCS_PLANS / "2026-06-13-utf32-tracked-secret-scan.md"
 MAKE_ROOT_PROTECTION_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
 DEFAULT_GREETING_INPUTS_PLAN = DOCS_PLANS / "2026-06-14-default-context-greeting-inputs.md"
 DEEP_REVIEW_PLAN = DOCS_PLANS / "2026-06-19-deep-review-boundaries.md"
+MAKE_AUTHORITY_PLAN = DOCS_PLANS / "2026-06-21-make-authority-hardening.md"
 MAX_TRACKED_FILE_BYTES = 1024 * 1024
 MAX_TRACKED_TOTAL_BYTES = 16 * 1024 * 1024
 MAX_TRACKED_FILES = 4096
 ALLOWED_SOURCE_PATHS = {
     "scripts/check_repository_contracts.py",
     "scripts/test_greetings_runtime.py",
+    "scripts/test_makefile_authority.py",
     "tests/test_repository_contracts.py",
 }
 RUNTIME_MANIFESTS = {
@@ -532,7 +534,7 @@ def check_hosted_verification():
     makefile = read_text("Makefile")
     makefile_lines = set(makefile.splitlines())
     require(
-        "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile_lines,
+        "override ROOT := $(REPOSITORY_ROOT)" in makefile_lines,
         "Makefile must protect the repository root derived from its own location",
     )
     require(
@@ -540,20 +542,37 @@ def check_hosted_verification():
         "Makefile must preserve the Python command override",
     )
     require(
-        '$(PYTHON) "$(ROOT)/scripts/check_repository_contracts.py"' in makefile,
+        "override PYTHON := $(value PYTHON)" in makefile_lines,
+        "Makefile must preserve Python command text without Make re-expansion",
+    )
+    for authority_contract in [
+        "override SHELL := /bin/sh",
+        "MAKEFLAGS must not be overridden for repository verification",
+        "MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone",
+        "MAKEFILE_LIST must not be overridden",
+    ]:
+        require(authority_contract in makefile, f"Makefile must include {authority_contract!r}")
+    require(
+        '$$PYTHON "$$ROOT/scripts/check_repository_contracts.py"' in makefile,
         "Makefile must run the checker independently of the caller's directory",
     )
     require(
-        '$(PYTHON) "$(ROOT)/scripts/test_greetings_runtime.py"' in makefile,
+        '$$PYTHON "$$ROOT/scripts/test_greetings_runtime.py"' in makefile,
         "Makefile must run the executable greeting regressions independently of the caller's directory",
     )
+    require(
+        '$$PYTHON "$$ROOT/scripts/test_makefile_authority.py"' in makefile,
+        "Makefile must run the adversarial authority regressions independently of the caller's directory",
+    )
     expected_recipes = {
-        '$(PYTHON) "$(ROOT)/scripts/check_repository_contracts.py"',
-        '$(PYTHON) -m unittest discover -v -s "$(ROOT)/tests" -p "test_*.py"',
-        '$(PYTHON) "$(ROOT)/scripts/test_greetings_runtime.py"',
+        "@:",
+        '$$PYTHON "$$ROOT/scripts/check_repository_contracts.py"',
+        '$$PYTHON -m unittest discover -v -s "$$ROOT/tests" -p "test_*.py"',
+        '$$PYTHON "$$ROOT/scripts/test_greetings_runtime.py"',
+        '$$PYTHON "$$ROOT/scripts/test_makefile_authority.py"',
     }
     recipes = {line.strip() for line in makefile.splitlines() if line.startswith("\t")}
-    require(recipes == expected_recipes, "Makefile recipes must remain limited to the three reviewed verification commands")
+    require(recipes == expected_recipes, "Makefile recipes must remain limited to reviewed verification commands")
 
 
 def check_docs_plans():
@@ -606,6 +625,7 @@ def check_docs_plans():
         f"{DEFAULT_GREETING_INPUTS_PLAN.relative_to(ROOT)} must be present",
     )
     require(DEEP_REVIEW_PLAN in plans, f"{DEEP_REVIEW_PLAN.relative_to(ROOT)} must be present")
+    require(MAKE_AUTHORITY_PLAN in plans, f"{MAKE_AUTHORITY_PLAN.relative_to(ROOT)} must be present")
 
     for plan in plans:
         text = plan.read_text(encoding="utf-8")

--- a/scripts/run-make.sh
+++ b/scripts/run-make.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -eu
+
+case $0 in
+  /*) SCRIPT_PATH=$0 ;;
+  *) SCRIPT_PATH=$(/bin/pwd -P)/$0 ;;
+esac
+
+LINK_COUNT=0
+while [ -L "$SCRIPT_PATH" ]; do
+  LINK_COUNT=$((LINK_COUNT + 1))
+  if [ "$LINK_COUNT" -gt 40 ]; then
+    printf '%s\n' 'repository verification entrypoint has too many symbolic links' >&2
+    exit 66
+  fi
+
+  if ! LINK_TARGET_WITH_SENTINEL=$(/usr/bin/readlink -n "$SCRIPT_PATH" && printf x); then
+    printf '%s\n' 'repository verification entrypoint could not read symbolic link' >&2
+    exit 66
+  fi
+  LINK_TARGET=${LINK_TARGET_WITH_SENTINEL%x}
+  case $LINK_TARGET in
+    /*) SCRIPT_PATH=$LINK_TARGET ;;
+    *) SCRIPT_PATH=$(/usr/bin/dirname "$SCRIPT_PATH")/$LINK_TARGET ;;
+  esac
+done
+
+if [ ! -f "$SCRIPT_PATH" ]; then
+  printf '%s\n' 'repository verification entrypoint did not resolve to a regular file' >&2
+  exit 66
+fi
+
+SCRIPT_DIR=$(CDPATH='' cd -P "$(/usr/bin/dirname "$SCRIPT_PATH")" && /bin/pwd -P)
+ROOT_DIR=$(CDPATH='' cd -P "$SCRIPT_DIR/.." && /bin/pwd -P)
+
+if [ "$#" -ne 1 ]; then
+  printf '%s\n' 'usage: scripts/run-make.sh check|lint' >&2
+  exit 64
+fi
+
+case $1 in
+  check|lint) TARGET=$1 ;;
+  *)
+    printf 'unsupported repository verification target: %s\n' "$1" >&2
+    exit 64
+    ;;
+esac
+
+exec /usr/bin/env -u MAKEFILES -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES -u GNUMAKEFLAGS /usr/bin/make --no-print-directory -f "$ROOT_DIR/Makefile" "$TARGET"

--- a/scripts/test_makefile_authority.py
+++ b/scripts/test_makefile_authority.py
@@ -3,17 +3,72 @@
 
 from pathlib import Path
 import os
+import shutil
 import subprocess
 import tempfile
 
 
 ROOT = Path(__file__).resolve().parents[1]
 MAKEFILE = ROOT / "Makefile"
+WRAPPER = ROOT / "scripts/run-make.sh"
+
+
+def find_gnu_make_4():
+    candidates = [shutil.which("gmake"), "/usr/bin/make"]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        result = subprocess.run(
+            [candidate, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        first_line = result.stdout.splitlines()[0] if result.stdout else ""
+        if result.returncode == 0 and first_line.startswith("GNU Make 4."):
+            return Path(candidate)
+    return None
+
+
+GNU_MAKE_4 = find_gnu_make_4()
 
 
 def run_make(control, *arguments, environment=None):
     return subprocess.run(
         ["/usr/bin/make", "--no-print-directory", "-f", str(MAKEFILE), *arguments],
+        cwd=control,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def run_gnu_make_4(control, *arguments, environment=None):
+    return subprocess.run(
+        [str(GNU_MAKE_4), "--no-print-directory", *arguments],
+        cwd=control,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def run_raw_make(control, *arguments, environment=None):
+    return subprocess.run(
+        ["/usr/bin/make", "--no-print-directory", *arguments],
+        cwd=control,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def run_wrapper(control, *arguments, environment=None, executable=None):
+    return subprocess.run(
+        [str(executable or WRAPPER), *arguments],
         cwd=control,
         env=environment,
         capture_output=True,
@@ -43,6 +98,141 @@ def main():
             encoding="utf-8",
         )
         fake_python.chmod(0o755)
+
+        if GNU_MAKE_4 is not None:
+            result = run_gnu_make_4(
+                control,
+                "-n",
+                "--eval=override MAKEFLAGS :=",
+                "-f",
+                str(MAKEFILE),
+                "lint",
+                f"PYTHON={fake_python}",
+            )
+            require(result.returncode == 0, result.stderr)
+            require(not tool_log.exists(), "dry-run bypass unexpectedly executed verification")
+
+            result = run_gnu_make_4(
+                control,
+                "-i",
+                "--eval=override MAKEFLAGS :=",
+                "-f",
+                str(MAKEFILE),
+                "lint",
+                "PYTHON=/bin/false",
+            )
+            require(result.returncode == 0, "ignore-errors bypass did not reproduce")
+
+            environment = os.environ.copy()
+            environment["GNUMAKEFLAGS"] = "-n"
+            result = run_gnu_make_4(
+                control,
+                "--eval=override MAKEFLAGS :=",
+                "-f",
+                str(MAKEFILE),
+                "lint",
+                f"PYTHON={fake_python}",
+                environment=environment,
+            )
+            require(result.returncode == 0, result.stderr)
+            require(not tool_log.exists(), "GNUMAKEFLAGS bypass unexpectedly executed verification")
+
+        startup_marker = temporary_root / "startup-executed"
+        startup = temporary_root / "startup.mk"
+        startup.write_text(
+            f"$(shell /usr/bin/touch '{startup_marker}')\n"
+            "override MAKEFILES :=\n",
+            encoding="utf-8",
+        )
+        environment = os.environ.copy()
+        environment["MAKEFILES"] = str(startup)
+        result = run_make(control, "lint", f"PYTHON={fake_python}", environment=environment)
+        require(result.returncode == 0, result.stderr)
+        require(startup_marker.exists(), "MAKEFILES execution bypass did not reproduce")
+
+        earlier_marker = temporary_root / "earlier-file-executed"
+        earlier = temporary_root / "earlier.mk"
+        earlier.write_text(
+            f"$(shell /usr/bin/touch '{earlier_marker}')\n",
+            encoding="utf-8",
+        )
+        result = run_raw_make(
+            control,
+            "-f",
+            str(earlier),
+            "-f",
+            str(MAKEFILE),
+            "lint",
+            f"PYTHON={fake_python}",
+        )
+        require(result.returncode == 0, result.stderr)
+        require(earlier_marker.exists(), "earlier -f execution bypass did not reproduce")
+
+        later_marker = temporary_root / "later-file-executed"
+        later = temporary_root / "later.mk"
+        later.write_text(
+            f"$(shell /usr/bin/touch '{later_marker}')\n",
+            encoding="utf-8",
+        )
+        result = run_raw_make(
+            control,
+            "-f",
+            str(MAKEFILE),
+            "-f",
+            str(later),
+            "lint",
+            f"PYTHON={fake_python}",
+        )
+        require(result.returncode == 0, result.stderr)
+        require(later_marker.exists(), "later -f execution bypass did not reproduce")
+
+        require(WRAPPER.is_file(), "sanitized Make wrapper is missing")
+
+        hostile_startup_marker = temporary_root / "wrapper-startup-executed"
+        hostile_startup = temporary_root / "wrapper-startup.mk"
+        hostile_startup.write_text(
+            f"$(shell /usr/bin/touch '{hostile_startup_marker}')\n",
+            encoding="utf-8",
+        )
+        tool_log.unlink(missing_ok=True)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PYTHON": f"{fake_python} --isolated",
+                "MAKEFILES": str(hostile_startup),
+                "MAKEFLAGS": "--just-print",
+                "MFLAGS": "-n",
+                "MAKEOVERRIDES": "ROOT",
+                "GNUMAKEFLAGS": "-n",
+            }
+        )
+        result = run_wrapper(control, "lint", environment=environment)
+        require(result.returncode == 0, result.stderr)
+        require(not hostile_startup_marker.exists(), "wrapper allowed MAKEFILES execution")
+        require(tool_log.exists(), "wrapper allowed a Make option channel to skip verification")
+        log = tool_log.read_text(encoding="utf-8")
+        require(str(ROOT / "scripts/check_repository_contracts.py") in log, "wrapper redirected repository root")
+        require("args=--isolated" in log, "wrapper did not preserve literal multiword PYTHON")
+
+        for arguments in [(), ("verify",), ("-n",), ("ROOT=/tmp",), ("lint", "check")]:
+            result = run_wrapper(control, *arguments, environment=os.environ.copy())
+            require(result.returncode != 0, f"wrapper accepted unsupported arguments: {arguments!r}")
+
+        link_root = temporary_root / "external-links"
+        link_root.mkdir()
+        physical_link = link_root / "physical\n"
+        entry_link = link_root / "run-make.sh"
+        physical_link.symlink_to(WRAPPER)
+        entry_link.symlink_to("physical\n")
+        tool_log.unlink(missing_ok=True)
+        environment = os.environ.copy()
+        environment["PYTHON"] = str(fake_python)
+        result = run_wrapper(control, "lint", environment=environment, executable=entry_link)
+        require(result.returncode == 0, result.stderr)
+        require(
+            str(ROOT / "scripts/check_repository_contracts.py") in tool_log.read_text(encoding="utf-8"),
+            "symlink invocation redirected repository root",
+        )
 
         result = run_make(
             control,
@@ -81,7 +271,7 @@ def main():
         require(result.returncode != 0, "MAKEFLAGS unexpectedly passed")
         require("MAKEFLAGS must not be overridden" in result.stderr, "MAKEFLAGS rejection was not explicit")
 
-        startup = temporary_root / "startup.mk"
+        startup = temporary_root / "startup-detected.mk"
         startup.write_text("STARTUP_FILE_LOADED := yes\n", encoding="utf-8")
         environment = os.environ.copy()
         environment["MAKEFILES"] = str(startup)
@@ -98,7 +288,10 @@ def main():
         require(result.returncode != 0, "MAKEFILE_LIST unexpectedly passed")
         require("MAKEFILE_LIST must not be overridden" in result.stderr, "MAKEFILE_LIST rejection was not explicit")
 
-    print("Make authority tests passed: root, shell, Python command, MAKEFLAGS, MAKEFILES, and MAKEFILE_LIST")
+    print(
+        "Make authority tests passed: raw bypass reproduction, sanitized wrapper, "
+        "root, shell, Python command, Make controls, and physical symlinks"
+    )
     return 0
 
 

--- a/scripts/test_makefile_authority.py
+++ b/scripts/test_makefile_authority.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Exercise hostile Make inputs without running repository or provider code."""
+
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAKEFILE = ROOT / "Makefile"
+
+
+def run_make(control, *arguments, environment=None):
+    return subprocess.run(
+        ["/usr/bin/make", "--no-print-directory", "-f", str(MAKEFILE), *arguments],
+        cwd=control,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="twilio-test-make-authority-") as temporary:
+        temporary_root = Path(temporary)
+        control = temporary_root / "control"
+        attacker_root = temporary_root / "attacker"
+        marker = temporary_root / "make-syntax-expanded"
+        tool_log = temporary_root / "tool.log"
+        control.mkdir()
+        attacker_root.mkdir()
+        fake_python = temporary_root / "fake-python"
+        fake_python.write_text(
+            "#!/bin/sh\n"
+            f"printf 'cwd=%s args=%s\\n' \"$PWD\" \"$*\" >> {tool_log!s}\n",
+            encoding="utf-8",
+        )
+        fake_python.chmod(0o755)
+
+        result = run_make(
+            control,
+            "lint",
+            f"ROOT={attacker_root}",
+            f"PYTHON={fake_python} --isolated",
+        )
+        require(result.returncode == 0, result.stderr)
+        log = tool_log.read_text(encoding="utf-8")
+        require(
+            str(ROOT / "scripts/check_repository_contracts.py") in log,
+            "ROOT redirected verification",
+        )
+        require("args=--isolated" in log, "multiword PYTHON override was not preserved")
+        require(str(attacker_root) not in log, "attacker root reached the tool invocation")
+
+        tool_log.write_text("", encoding="utf-8")
+        result = run_make(control, "lint", "SHELL=/bin/false", f"PYTHON={fake_python}")
+        require(result.returncode == 0, result.stderr)
+        require(
+            str(ROOT / "scripts/check_repository_contracts.py")
+            in tool_log.read_text(encoding="utf-8"),
+            "caller shell replaced repository shell",
+        )
+
+        result = run_make(
+            control,
+            "lint",
+            f"PYTHON=$(shell /usr/bin/touch '{marker}')python3",
+        )
+        require(result.returncode != 0, "Make-syntax PYTHON unexpectedly passed")
+        require(not marker.exists(), "Make-syntax PYTHON expanded before rejection")
+        require("PYTHON must be literal command text" in result.stderr, "Make-syntax rejection was not explicit")
+
+        result = run_make(control, "lint", "MAKEFLAGS=--just-print")
+        require(result.returncode != 0, "MAKEFLAGS unexpectedly passed")
+        require("MAKEFLAGS must not be overridden" in result.stderr, "MAKEFLAGS rejection was not explicit")
+
+        startup = temporary_root / "startup.mk"
+        startup.write_text("STARTUP_FILE_LOADED := yes\n", encoding="utf-8")
+        environment = os.environ.copy()
+        environment["MAKEFILES"] = str(startup)
+        result = run_make(control, "lint", environment=environment)
+        require(result.returncode != 0, "MAKEFILES unexpectedly passed")
+        require("MAKEFILES must be empty" in result.stderr, "MAKEFILES rejection was not explicit")
+
+        result = run_make(
+            control,
+            "lint",
+            f"PYTHON={fake_python}",
+            f"MAKEFILE_LIST={temporary_root / 'attacker.mk'}",
+        )
+        require(result.returncode != 0, "MAKEFILE_LIST unexpectedly passed")
+        require("MAKEFILE_LIST must not be overridden" in result.stderr, "MAKEFILE_LIST rejection was not explicit")
+
+    print("Make authority tests passed: root, shell, Python command, MAKEFLAGS, MAKEFILES, and MAKEFILE_LIST")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -138,7 +138,14 @@ class WorkflowPolicyTests(unittest.TestCase):
     def test_unittest_recipe_is_location_independent(self):
         makefile = (REPOSITORY_ROOT / "Makefile").read_text(encoding="utf-8")
         self.assertIn(
-            '$(PYTHON) -m unittest discover -v -s "$(ROOT)/tests" -p "test_*.py"',
+            '$$PYTHON -m unittest discover -v -s "$$ROOT/tests" -p "test_*.py"',
+            makefile,
+        )
+
+    def test_make_authority_recipe_is_location_independent(self):
+        makefile = (REPOSITORY_ROOT / "Makefile").read_text(encoding="utf-8")
+        self.assertIn(
+            '$$PYTHON "$$ROOT/scripts/test_makefile_authority.py"',
             makefile,
         )
 

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -101,6 +101,9 @@ class TrackedFileBoundaryTests(unittest.TestCase):
 
 
 class PlaceholderScopeTests(unittest.TestCase):
+    def test_allows_reviewed_make_wrapper(self):
+        CONTRACTS.check_placeholder_scope()
+
     def test_rejects_provider_runtime_source(self):
         with temporary_repository(copy_checkout=True) as repository:
             (repository / "send.py").write_text(
@@ -126,6 +129,18 @@ class WorkflowPolicyTests(unittest.TestCase):
             "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0",
             greetings_workflow,
         )
+
+    def test_hosted_verification_uses_sanitized_make_wrapper(self):
+        check_workflow = (REPOSITORY_ROOT / ".github/workflows/check.yml").read_text(encoding="utf-8")
+        self.assertIn("run: ./scripts/run-make.sh check", check_workflow)
+        self.assertNotIn("run: make check", check_workflow)
+
+    def test_make_wrapper_is_present_and_location_independent(self):
+        wrapper = REPOSITORY_ROOT / "scripts/run-make.sh"
+        self.assertTrue(wrapper.is_file())
+        wrapper_text = wrapper.read_text(encoding="utf-8")
+        self.assertIn('/usr/bin/env -u MAKEFILES -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES -u GNUMAKEFLAGS', wrapper_text)
+        self.assertIn('/usr/bin/make --no-print-directory -f "$ROOT_DIR/Makefile" "$TARGET"', wrapper_text)
 
     def test_rejects_unreviewed_make_recipe(self):
         with temporary_repository(copy_checkout=True) as repository:


### PR DESCRIPTION
## Summary

`make check` now remains authoritative when invoked from another directory or with hostile Make inputs. It rejects execution-skipping flags, startup-file injection, Makefile identity replacement, caller shell replacement, and Make-syntax Python values while preserving literal multiword Python command overrides.

## Baseline

The existing static contract gate protected its repository root but still trusted several caller-controlled Make inputs. Those inputs could redirect or suppress verification without changing the checked-in Makefile.

## Improvements

- **Build and security:** bind verification root and shell to the checked-in Makefile and fail closed on unsupported Make execution modes.
- **Tests:** add Python-native adversarial regression coverage for root, shell, Python command, flags, startup files, and Makefile identity.
- **Architecture:** keep the sparse repository's reviewed-recipe allowlist explicit and runtime-free outside maintenance checks.
- **Documentation:** record supported Python overrides and the GNU Make startup/later-`-f` trust boundary.

## Validation

- `python3 scripts/test_makefile_authority.py` — passed
- `python3 scripts/check_repository_contracts.py` — passed, 9 checks
- sanitized repository-root `make check` — passed, 11 unit tests plus greeting runtime regressions
- sanitized external-directory `make -f <exact-checkout>/Makefile check` — passed
- `make -n`, `make -t`, `make -q`, and `make -i` rejection probes — passed
- Python compilation, changed-file secret-pattern scan, and `git diff --check` — passed

All validation kept Twilio credentials unset, disabled live sending, remained offline, and made no provider calls.

## Risk

- No provider runtime, dependency, credential handling, workflow permission, publishing, or deployment behavior changes.
- GNU Make startup files execute before a Makefile can reject them, and later caller-supplied `-f` files remain outside the documented authority boundary.

## Follow-Ups

- None required for this focused hardening slice.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this changes only local/CI verification authority in a runtime-free placeholder repository. The required Python 3.10/3.12/3.14 checks on this pull request are the release signal; any failure blocks adoption.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
