### PR TITLE
Scan staged blobs for tracked secrets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## 2026-06-25 07:01 PDT
+
+- Closed the local staged-secret bypass by scanning immutable index blobs in
+  addition to safely opened worktree files.
+- Preserved Git object IDs from canonical index entries and bounded staged
+  blobs with the same per-file and aggregate limits as worktree snapshots.
+- Added regressions proving that neither a benign unstaged edit nor a benign
+  staged snapshot can hide a secret in the other tracked state.
+
 - Added a physical-root `check|lint` wrapper for hosted and contributor
   verification, clearing all five GNU Make control variables before Make starts
   and covering dry-run, ignore-errors, startup-file, `--eval`, and extra-`-f`

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ When the required SDK or runtime is unavailable, use static checks and source re
   not casually stage credentials, account identifiers, customer payloads, or
   HTTP archive captures.
 - Packet captures, trace files, Wrangler local secrets, PEM files, and key files
-  are also ignored. The checker opens only tracked regular files without
-  following links, rejects files above 1 MiB, caps the aggregate scan at 16 MiB,
-  and scans UTF-8 (including BOM), UTF-16, and UTF-32 text in either byte order
-  for real-looking Twilio SIDs, token/phone assignments, and private keys.
+  are also ignored. The checker scans both each staged Git blob and its current
+  worktree file, opens worktree files without following links, rejects either
+  snapshot above 1 MiB, caps all bytes scanned at 16 MiB, and scans UTF-8
+  (including BOM), UTF-16, and UTF-32 text in either byte order for real-looking
+  Twilio SIDs, token/phone assignments, and private keys.
   Strongly identified BOM-less UTF-16/UTF-32 text is included; unrecognized
   binary data remains skipped. Token and phone checks cover shell exports plus
   dotenv, YAML, and JSON assignments.
@@ -143,6 +144,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   runtime-free placeholder enforcement, and current workflow pins.
 - See `docs/plans/2026-06-21-make-authority-hardening.md` for Python command,
   shell, flag, startup-file, and Makefile-identity authority checks.
+- See `docs/plans/2026-06-25-staged-secret-snapshot-scan.md` for staged-index
+  and worktree secret scanning that cannot be bypassed by an unstaged edit.
 - The pinned first-interaction v3.1.0 implementation reads both greeting
   message inputs on every supported event; each event-scoped job therefore
   supplies both non-secret messages while retaining its narrow write scope.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,10 +31,11 @@ Helpful reports include:
 - Local `.env`, debug log, and HAR capture files should stay ignored because
   they can contain credentials, account identifiers, request URLs, or payloads.
 - Packet captures, trace files, `.dev.vars`, PEM files, and private key files
-  should remain ignored. The repository gate scans all tracked UTF-8 text and
-  BOM-marked UTF-16 and UTF-32 little-endian and big-endian text for
-  real-looking Twilio SIDs, populated token/phone assignments, and private-key
-  blocks while leaving unrecognized binary data uninterpreted.
+  should remain ignored. The repository gate scans both staged Git blobs and
+  their current worktree files across UTF-8 text and BOM-marked UTF-16 and
+  UTF-32 little-endian and big-endian text for real-looking Twilio SIDs,
+  populated token/phone assignments, and private-key blocks while leaving
+  unrecognized binary data uninterpreted.
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - Use `./scripts/run-make.sh check` for repository verification. The wrapper
   resolves the physical checkout, accepts only the reviewed `check` or `lint`

--- a/VISION.md
+++ b/VISION.md
@@ -20,6 +20,7 @@ Priority:
 - Ignore local environment files, debug logs, and HAR captures
 - Ignore packet captures, traces, local Worker secrets, and key material
 - Scan all tracked text for real-looking Twilio identifiers and secrets
+- Scan staged Git blobs and current worktree files as separate snapshots
 - Scan BOM-marked UTF-16 tracked text without treating arbitrary binary as text
 - Scan BOM-marked UTF-32 tracked text before overlapping UTF-16 BOM prefixes
 - Scan common shell, dotenv, YAML, and JSON secret assignment syntaxes

--- a/docs/plans/2026-06-25-staged-secret-snapshot-scan.md
+++ b/docs/plans/2026-06-25-staged-secret-snapshot-scan.md
@@ -1,0 +1,37 @@
+# Staged Secret Snapshot Scan
+
+Status: Completed
+
+## Context
+
+The tracked-secret gate enumerated the Git index but read content only from the
+worktree. A contributor could stage a real-looking Twilio credential and then
+replace the worktree file with benign text before running the local gate. The
+check would pass even though the next commit still contained the staged secret.
+
+## Design
+
+Preserve each canonical object ID returned by `git ls-files --stage`. Read the
+immutable staged blob with `git cat-file`, reject non-regular modes, malformed
+object IDs, unreadable objects, and blobs above the existing 1 MiB limit. Scan
+that staged snapshot and the current worktree snapshot independently while
+sharing the existing 16 MiB aggregate budget.
+
+Keep the worktree scan because an unstaged secret must also fail locally. Its
+existing `lstat`, `O_NOFOLLOW`, inode, type, and growth checks remain the safe
+boundary for filesystem content.
+
+## Alternatives Considered
+
+- Scanning only `HEAD` would miss newly staged content.
+- Scanning only the index would miss an unstaged secret about to be staged.
+- Reconstructing a temporary checkout would add filesystem and cleanup risk
+  without improving on immutable blob reads.
+
+## Verification
+
+- A staged token followed by a benign worktree edit must fail.
+- A benign staged blob followed by an unstaged token must fail.
+- Existing symlink, file-size, aggregate-size, and encoded-text tests stay
+  green.
+- `make check` runs the complete repository contract suite.

--- a/scripts/check_repository_contracts.py
+++ b/scripts/check_repository_contracts.py
@@ -26,6 +26,7 @@ MAKE_ROOT_PROTECTION_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protecti
 DEFAULT_GREETING_INPUTS_PLAN = DOCS_PLANS / "2026-06-14-default-context-greeting-inputs.md"
 DEEP_REVIEW_PLAN = DOCS_PLANS / "2026-06-19-deep-review-boundaries.md"
 MAKE_AUTHORITY_PLAN = DOCS_PLANS / "2026-06-21-make-authority-hardening.md"
+STAGED_SECRET_SNAPSHOT_PLAN = DOCS_PLANS / "2026-06-25-staged-secret-snapshot-scan.md"
 MAX_TRACKED_FILE_BYTES = 1024 * 1024
 MAX_TRACKED_TOTAL_BYTES = 16 * 1024 * 1024
 MAX_TRACKED_FILES = 4096
@@ -199,14 +200,18 @@ def tracked_index_entries():
     for record in records:
         try:
             metadata, path_bytes = record.split(b"\t", 1)
-            mode, _object_id, stage = metadata.split(b" ", 2)
+            mode, object_id, stage = metadata.split(b" ", 2)
             relative_path = path_bytes.decode("utf-8")
         except (UnicodeDecodeError, ValueError) as exc:
             raise AssertionError("tracked paths and index records must use canonical UTF-8") from exc
         path = Path(relative_path)
         require(not path.is_absolute() and ".." not in path.parts, "tracked path must remain repository-relative")
         require(stage == b"0", f"{relative_path} must not contain unresolved index stages")
-        entries.append((mode.decode("ascii"), relative_path))
+        require(
+            re.fullmatch(rb"(?:[0-9a-f]{40}|[0-9a-f]{64})", object_id) is not None,
+            f"{relative_path} must reference a canonical Git object ID",
+        )
+        entries.append((mode.decode("ascii"), object_id.decode("ascii"), relative_path))
     return entries
 
 
@@ -246,6 +251,33 @@ def read_tracked_regular_file(mode, relative_path):
     return bytes(data)
 
 
+def read_tracked_index_blob(mode, object_id, relative_path):
+    require(mode in {"100644", "100755"}, f"{relative_path} must be a tracked regular file, not a symlink or special entry")
+    try:
+        size_result = subprocess.run(
+            ["git", "-C", str(ROOT), "cat-file", "-s", object_id],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        size = int(size_result.stdout.strip())
+    except (subprocess.SubprocessError, ValueError) as exc:
+        raise AssertionError(f"{relative_path} staged blob size could not be read safely") from exc
+    require(size <= MAX_TRACKED_FILE_BYTES, f"{relative_path} staged blob exceeds the tracked-file size limit")
+    try:
+        blob_result = subprocess.run(
+            ["git", "-C", str(ROOT), "cat-file", "blob", object_id],
+            check=True,
+            capture_output=True,
+            timeout=10,
+        )
+    except subprocess.SubprocessError as exc:
+        raise AssertionError(f"{relative_path} staged blob could not be read safely") from exc
+    require(len(blob_result.stdout) == size, f"{relative_path} staged blob size changed while scanned")
+    return blob_result.stdout
+
+
 def check_required_files():
     for relative_path in [
         ".gitignore",
@@ -281,7 +313,11 @@ def check_placeholder_scope():
         "docs/plans/2026-06-08-secret-hygiene.md" in readme,
         "README must link the secret hygiene plan",
     )
-    for _mode, relative_path in tracked_index_entries():
+    require(
+        "docs/plans/2026-06-25-staged-secret-snapshot-scan.md" in readme,
+        "README must link the staged secret snapshot plan",
+    )
+    for _mode, _object_id, relative_path in tracked_index_entries():
         path = Path(relative_path)
         is_runtime_surface = path.name in RUNTIME_MANIFESTS or path.suffix.lower() in RUNTIME_SUFFIXES
         require(
@@ -387,21 +423,25 @@ def check_secret_hygiene():
 
 def check_tracked_secret_patterns():
     total_bytes = 0
-    for mode, relative_path in tracked_index_entries():
-        data = read_tracked_regular_file(mode, relative_path)
-        total_bytes += len(data)
-        require(
-            total_bytes <= MAX_TRACKED_TOTAL_BYTES,
-            f"tracked-file aggregate scan exceeds the {MAX_TRACKED_TOTAL_BYTES}-byte budget",
-        )
-        text = decode_tracked_text(data)
-        if text is None:
-            continue
-        for pattern, description in TRACKED_SECRET_PATTERNS:
+    for mode, object_id, relative_path in tracked_index_entries():
+        snapshots = [
+            ("staged", read_tracked_index_blob(mode, object_id, relative_path)),
+            ("worktree", read_tracked_regular_file(mode, relative_path)),
+        ]
+        for snapshot_name, data in snapshots:
+            total_bytes += len(data)
             require(
-                pattern.search(text) is None,
-                f"{relative_path} contains a real-looking {description}",
+                total_bytes <= MAX_TRACKED_TOTAL_BYTES,
+                f"tracked-file aggregate scan exceeds the {MAX_TRACKED_TOTAL_BYTES}-byte budget",
             )
+            text = decode_tracked_text(data)
+            if text is None:
+                continue
+            for pattern, description in TRACKED_SECRET_PATTERNS:
+                require(
+                    pattern.search(text) is None,
+                    f"{relative_path} {snapshot_name} snapshot contains a real-looking {description}",
+                )
 
 
 def check_secret_pattern_syntaxes():
@@ -643,6 +683,10 @@ def check_docs_plans():
     )
     require(DEEP_REVIEW_PLAN in plans, f"{DEEP_REVIEW_PLAN.relative_to(ROOT)} must be present")
     require(MAKE_AUTHORITY_PLAN in plans, f"{MAKE_AUTHORITY_PLAN.relative_to(ROOT)} must be present")
+    require(
+        STAGED_SECRET_SNAPSHOT_PLAN in plans,
+        f"{STAGED_SECRET_SNAPSHOT_PLAN.relative_to(ROOT)} must be present",
+    )
 
     for plan in plans:
         text = plan.read_text(encoding="utf-8")

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -3,6 +3,7 @@
 
 from contextlib import contextmanager
 import importlib.util
+import inspect
 import os
 from pathlib import Path
 import shutil
@@ -63,12 +64,33 @@ class TrackedTextDecodingTests(unittest.TestCase):
 
 
 class TrackedFileBoundaryTests(unittest.TestCase):
+    def test_worktree_reader_preserves_no_follow_open(self):
+        source = inspect.getsource(CONTRACTS.read_tracked_regular_file)
+        self.assertIn('getattr(os, "O_NOFOLLOW", 0)', source)
+        self.assertIn("os.fstat(descriptor)", source)
+
     def test_rejects_tracked_symlink_without_following_it(self):
         with temporary_repository() as repository:
             outside = repository.parent / "outside.txt"
             outside.write_text("benign", encoding="utf-8")
             os.symlink(outside, repository / "linked.txt")
             git(repository, "add", "linked.txt")
+
+            with self.assertRaisesRegex(AssertionError, "symlink|regular file"):
+                CONTRACTS.check_tracked_secret_patterns()
+
+    def test_rejects_worktree_symlink_for_regular_staged_file(self):
+        with temporary_repository() as repository:
+            outside = repository.parent / "outside-secret.txt"
+            outside.write_text(
+                "TWILIO_AUTH_TOKEN=" + "0123456789abcdef" * 2,
+                encoding="utf-8",
+            )
+            tracked_file = repository / "linked-after-stage.txt"
+            tracked_file.write_text("benign staged content\n", encoding="utf-8")
+            git(repository, "add", "linked-after-stage.txt")
+            tracked_file.unlink()
+            os.symlink(outside, tracked_file)
 
             with self.assertRaisesRegex(AssertionError, "symlink|regular file"):
                 CONTRACTS.check_tracked_secret_patterns()
@@ -97,6 +119,42 @@ class TrackedFileBoundaryTests(unittest.TestCase):
             git(repository, "add", "encoded.txt")
 
             with self.assertRaisesRegex(AssertionError, "Twilio auth token"):
+                CONTRACTS.check_tracked_secret_patterns()
+
+    def test_rejects_staged_secret_hidden_by_benign_worktree_edit(self):
+        with temporary_repository() as repository:
+            tracked_file = repository / "staged.txt"
+            tracked_file.write_text(
+                "TWILIO_AUTH_TOKEN=" + "0123456789abcdef" * 2,
+                encoding="utf-8",
+            )
+            git(repository, "add", "staged.txt")
+            tracked_file.write_text("benign worktree content\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(AssertionError, "staged.txt.*Twilio auth token"):
+                CONTRACTS.check_tracked_secret_patterns()
+
+    def test_rejects_oversized_staged_blob_hidden_by_small_worktree_edit(self):
+        with temporary_repository() as repository:
+            tracked_file = repository / "staged-large.txt"
+            tracked_file.write_bytes(b"a" * (1024 * 1024 + 1))
+            git(repository, "add", "staged-large.txt")
+            tracked_file.write_text("small worktree content\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(AssertionError, "staged-large.txt.*size limit"):
+                CONTRACTS.check_tracked_secret_patterns()
+
+    def test_rejects_worktree_secret_hidden_by_benign_staged_snapshot(self):
+        with temporary_repository() as repository:
+            tracked_file = repository / "worktree.txt"
+            tracked_file.write_text("benign staged content\n", encoding="utf-8")
+            git(repository, "add", "worktree.txt")
+            tracked_file.write_text(
+                "TWILIO_AUTH_TOKEN=" + "0123456789abcdef" * 2,
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(AssertionError, "worktree.txt.*Twilio auth token"):
                 CONTRACTS.check_tracked_secret_patterns()
 
 


### PR DESCRIPTION
## Summary
- preserve canonical Git object IDs when enumerating tracked index entries
- scan immutable staged blobs and current worktree files as separate bounded snapshots
- document the local staged-secret boundary and add two-sided regression coverage

## Verification
- `./scripts/run-make.sh check`
- `python3 -m unittest -v tests.test_repository_contracts.TrackedFileBoundaryTests`
- six hostile mutations killed: staged scan removal, worktree scan removal, staged size-bound removal, `O_NOFOLLOW` removal, aggregate-bound removal, and object-ID discard
