### PR TITLE
Scan shell and PowerShell secret assignments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,9 @@
 - No required secret or credential file was identified in the repository scan. Local `.env` files and debug logs are ignored so future Twilio experiments do not casually stage credentials, account identifiers, customer payloads, or HTTP archive captures.
 - `.env.example` documents expected Twilio variable names with empty values and keeps live sends disabled by default, including a placeholder body for future message smoke tests and an `info` log-level default. Each placeholder includes a short comment describing what may be filled locally and what must stay empty in git. Static checks require credential, phone-number, and body placeholders to remain empty and reject duplicate or undocumented Twilio placeholder entries.
 - Keep local Twilio credentials and debug output out of git; `.env` files and `*.log` and `*.har` files are intentionally ignored. Common local OS and IDE metadata files are ignored as well.
+- Tracked-secret assignment detection covers bare, quoted, `export`, `local`,
+  `readonly`, `declare`, `typeset`, and PowerShell `$env:` forms for Twilio
+  token and phone placeholders.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-twilio-test-baseline.md` for the canonical placeholder contract baseline.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,57 @@
 # Changes
 
+## 2026-06-26 02:42 PDT - P2 - Scan shell declaration secrets
+
+### Summary
+Closed tracked-secret scanner gaps for common shell declaration prefixes and
+PowerShell environment assignments without broadening the placeholder into a
+provider runtime.
+
+### Work completed
+- Centralized the optional assignment prefix shared by Twilio auth-token and
+  phone-number patterns.
+- Added `local`, `readonly`, `declare`, and `typeset` shell declaration forms,
+  including bounded repeated options such as `-x -r`, `-xr`, and `--`.
+- Added case-insensitive PowerShell `$env:` assignment coverage.
+- Preserved existing bare, quoted, `export`, dotenv, YAML, and JSON matching.
+- Added end-to-end staged/worktree regressions and embedded syntax contracts.
+
+### Threads
+- Started: none.
+- Continued: tracked secret hygiene — assignment grammar coverage complete.
+- Stopped: none.
+
+### Files changed
+- `scripts/check_repository_contracts.py` — expands the shared secret assignment
+  grammar and binds the completed plan into repository contracts.
+- `tests/test_repository_contracts.py` — proves shell declarations and
+  PowerShell environment assignments are rejected from tracked snapshots.
+- Documentation and plan files — record the supported syntax and validation.
+
+### Validation
+- Red-first focused unittest command — five original shell/PowerShell fixtures
+  bypassed the old scanner, then passed after implementation.
+- Follow-up red-first shell test — repeated `declare -x -r` and `readonly --`
+  options bypassed the first grammar, then passed after bounded option support.
+- `./scripts/run-make.sh check` — passed with 21 behavioral tests under `C` and
+  `C.UTF-8`.
+- `make build|check|lint|root-test|test|verify` — passed under both locales and
+  from `/tmp` through the absolute Makefile path.
+- Shell-prefix and PowerShell-prefix removal mutations — both rejected.
+- Python compilation, shell syntax, and `git diff --check` — passed.
+- Hosted Python/CodeQL exact-head checks and review remain the next action.
+
+### Bugs / findings
+- P2: `readonly`, `declare`, `typeset`, and PowerShell `$env:` assignments could
+  previously carry real-looking Twilio tokens or phone numbers undetected.
+
+### Blockers
+- None; this repository remains dependency-free and performs no live Twilio
+  calls.
+
+### Next action
+- Open the focused PR, run exact-head hosted validation and review, then merge.
+
 ## 2026-06-25 07:01 PDT
 
 - Closed the local staged-secret bypass by scanning immutable index blobs in

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
   (including BOM), UTF-16, and UTF-32 text in either byte order for real-looking
   Twilio SIDs, token/phone assignments, and private keys.
   Strongly identified BOM-less UTF-16/UTF-32 text is included; unrecognized
-  binary data remains skipped. Token and phone checks cover shell exports plus
-  dotenv, YAML, and JSON assignments.
+  binary data remains skipped. Token and phone checks cover bare and quoted
+  dotenv, YAML, and JSON assignments, shell `export`, `local`, `readonly`,
+  `declare`, and `typeset` declarations, plus PowerShell `$env:` assignments.
 - `.env.example` documents expected Twilio variable names with empty values and
   keeps live sends disabled by default, including a placeholder body for future
   message smoke tests and an `info` log-level default. Each placeholder
@@ -136,6 +137,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   pattern and local capture-artifact coverage.
 - See `docs/plans/2026-06-10-secret-assignment-syntaxes.md` for shell, dotenv,
   YAML, and JSON credential-assignment coverage.
+- See `docs/plans/2026-06-26-shell-secret-assignment-syntaxes.md` for shell
+  declaration and PowerShell environment-assignment coverage.
 - See `docs/plans/2026-06-13-utf16-tracked-secret-scan.md` for the UTF-16
   tracked-text encoding boundary.
 - See `docs/plans/2026-06-13-utf32-tracked-secret-scan.md` for the UTF-32 BOM

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,9 @@ Helpful reports include:
   their current worktree files across UTF-8 text and BOM-marked UTF-16 and
   UTF-32 little-endian and big-endian text for real-looking Twilio SIDs,
   populated token/phone assignments, and private-key blocks while leaving
-  unrecognized binary data uninterpreted.
+  unrecognized binary data uninterpreted. Assignment scanning includes common
+  shell declarations and PowerShell `$env:` syntax in addition to dotenv,
+  YAML, and JSON forms.
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - Use `./scripts/run-make.sh check` for repository verification. The wrapper
   resolves the physical checkout, accepts only the reviewed `check` or `lint`

--- a/VISION.md
+++ b/VISION.md
@@ -23,7 +23,8 @@ Priority:
 - Scan staged Git blobs and current worktree files as separate snapshots
 - Scan BOM-marked UTF-16 tracked text without treating arbitrary binary as text
 - Scan BOM-marked UTF-32 tracked text before overlapping UTF-16 BOM prefixes
-- Scan common shell, dotenv, YAML, and JSON secret assignment syntaxes
+- Scan common shell declarations, PowerShell environment assignments, dotenv,
+  YAML, and JSON secret assignment syntaxes
 - Ignore local OS and IDE metadata
 - Keep environment examples placeholder-only and live sends disabled
 - Keep future message-body placeholders empty until an implementation exists

--- a/docs/plans/2026-06-26-shell-secret-assignment-syntaxes.md
+++ b/docs/plans/2026-06-26-shell-secret-assignment-syntaxes.md
@@ -1,0 +1,60 @@
+# Shell and PowerShell Secret Assignment Syntaxes
+
+Status: Completed
+
+## Context
+
+The tracked snapshot scanner rejected bare, quoted, exported, dotenv, YAML,
+and JSON Twilio assignments. Common shell declarations such as `readonly` and
+`declare -x`, plus PowerShell `$env:` assignments, placed text before the
+reviewed variable key and bypassed both token and phone patterns.
+
+## Design
+
+- Share one optional assignment-prefix grammar between auth-token and phone
+  patterns.
+- Accept `export`, `local`, `readonly`, `declare`, and `typeset`, with bounded
+  repeated alphabetic `-`/`+` flags or `--`.
+- Accept case-insensitive PowerShell `$env:` prefixes.
+- Preserve the existing anchored key, separator, value, encoding, staged blob,
+  worktree, size, and symlink boundaries.
+- Keep the repository runtime-free and avoid generic entropy scanning.
+
+## Test First
+
+Focused end-to-end tests staged real-looking values under `readonly`,
+`declare -x`, `typeset -xr`, and PowerShell `$env:` forms. All five original
+fixtures passed through the old scanner and failed the test before the shared
+prefix grammar was implemented. A `local` fixture completed the reviewed shell
+declaration set. Follow-up red tests proved repeated `declare -x -r` options
+and `readonly --` also required bounded option-sequence handling.
+
+## Verification
+
+- Run the focused shell and PowerShell unittest methods.
+- Run sanitized `make check` through `./scripts/run-make.sh check` under `C`
+  and `C.UTF-8`.
+- Run every public Make target from the checkout and an external directory.
+- Reject mutations that remove either shell declaration or PowerShell prefix
+  coverage.
+- Run shell/Python syntax checks and `git diff --check`.
+- Use hosted Python 3.10/3.12/3.14 and CodeQL checks as exact-head authority.
+
+## Scope Boundaries
+
+- No Twilio SDK, dependency, network request, live send, environment loader,
+  workflow trigger, greeting behavior, or Make authority change.
+- Detection remains key-specific and pattern-based rather than a general secret
+  scanner.
+
+## Verification Completed
+
+- The focused red-first tests failed for all five original bypass fixtures and
+  passed after implementation; two follow-up option-form fixtures also failed
+  before the final grammar and then passed. The full suite passed with 21 tests.
+- Sanitized `make check` passed under `C` and `C.UTF-8`; all six public Make
+  targets passed under both locales and from an external working directory.
+- Mutations removing shell declaration or PowerShell prefix support were both
+  rejected.
+- Python compilation, shell syntax checking, and `git diff --check` passed.
+- Hosted exact-head and review evidence will be recorded in the PR.

--- a/scripts/check_repository_contracts.py
+++ b/scripts/check_repository_contracts.py
@@ -20,6 +20,7 @@ LOCAL_METADATA_IGNORE_PLAN = DOCS_PLANS / "2026-06-09-local-metadata-ignore.md"
 WORKFLOW_HARDENING_PLAN = DOCS_PLANS / "2026-06-10-workflow-hardening-and-ci.md"
 TRACKED_SECRET_SCAN_PLAN = DOCS_PLANS / "2026-06-10-tracked-secret-scan.md"
 SECRET_SYNTAX_PLAN = DOCS_PLANS / "2026-06-10-secret-assignment-syntaxes.md"
+SHELL_SECRET_SYNTAX_PLAN = DOCS_PLANS / "2026-06-26-shell-secret-assignment-syntaxes.md"
 UTF16_SECRET_SCAN_PLAN = DOCS_PLANS / "2026-06-13-utf16-tracked-secret-scan.md"
 UTF32_SECRET_SCAN_PLAN = DOCS_PLANS / "2026-06-13-utf32-tracked-secret-scan.md"
 MAKE_ROOT_PROTECTION_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
@@ -83,17 +84,23 @@ RUNTIME_SUFFIXES = {
     ".tsx",
 }
 
+SECRET_ASSIGNMENT_PREFIX = (
+    r'''(?:(?:export|local|readonly|declare|typeset)'''
+    r'''(?:[ \t]+(?:[-+][A-Za-z]+|--))*[ \t]+'''
+    r'''|\$env:)?'''
+)
+
 TRACKED_SECRET_PATTERNS = [
     (re.compile(r"(?<![0-9A-Za-z])(AC|SK|SM|CA)[0-9a-fA-F]{32}(?![0-9A-Za-z])"), "Twilio SID"),
     (
         re.compile(
-            r'''(?im)^[ \t]*(?:export[ \t]+)?["']?TWILIO_AUTH_TOKEN["']?[ \t]*(?:=|:)[ \t]*["']?[0-9a-f]{32}(?![0-9a-f])'''
+            rf'''(?im)^[ \t]*{SECRET_ASSIGNMENT_PREFIX}["']?TWILIO_AUTH_TOKEN["']?[ \t]*(?:=|:)[ \t]*["']?[0-9a-f]{{32}}(?![0-9a-f])'''
         ),
         "Twilio auth token assignment",
     ),
     (
         re.compile(
-            r'''(?im)^[ \t]*(?:export[ \t]+)?["']?TWILIO_(FROM|TO)["']?[ \t]*(?:=|:)[ \t]*["']?\+?[0-9][0-9 ()-]{5,}'''
+            rf'''(?im)^[ \t]*{SECRET_ASSIGNMENT_PREFIX}["']?TWILIO_(FROM|TO)["']?[ \t]*(?:=|:)[ \t]*["']?\+?[0-9][0-9 ()-]{{5,}}'''
         ),
         "Twilio phone assignment",
     ),
@@ -317,6 +324,10 @@ def check_placeholder_scope():
         "docs/plans/2026-06-25-staged-secret-snapshot-scan.md" in readme,
         "README must link the staged secret snapshot plan",
     )
+    require(
+        "docs/plans/2026-06-26-shell-secret-assignment-syntaxes.md" in readme,
+        "README must link the shell secret assignment plan",
+    )
     for _mode, _object_id, relative_path in tracked_index_entries():
         path = Path(relative_path)
         is_runtime_surface = path.name in RUNTIME_MANIFESTS or path.suffix.lower() in RUNTIME_SUFFIXES
@@ -453,9 +464,17 @@ def check_secret_pattern_syntaxes():
         "TWILIO_AUTH_TOKEN: " + token,
         '"TWILIO_AUTH_TOKEN": "' + token + '"',
         "export TWILIO_AUTH_TOKEN=" + token,
+        "local TWILIO_AUTH_TOKEN=" + token,
+        "readonly TWILIO_AUTH_TOKEN=" + token,
+        "readonly -- TWILIO_FROM=" + second_phone,
+        "declare -x TWILIO_AUTH_TOKEN=" + token,
+        "declare -x -r TWILIO_AUTH_TOKEN=" + token,
+        "$env:TWILIO_AUTH_TOKEN = \"" + token + '"',
         "TWILIO_FROM: '" + second_phone + "'",
         '"TWILIO_TO": "' + third_phone + '"',
         "export TWILIO_TO=" + first_phone,
+        "typeset -xr TWILIO_FROM=" + second_phone,
+        "$env:TWILIO_TO = \"" + third_phone + '"',
     ]
     for fixture in secret_fixtures:
         require(
@@ -664,6 +683,10 @@ def check_docs_plans():
     require(
         SECRET_SYNTAX_PLAN in plans,
         f"{SECRET_SYNTAX_PLAN.relative_to(ROOT)} must be present",
+    )
+    require(
+        SHELL_SECRET_SYNTAX_PLAN in plans,
+        f"{SHELL_SECRET_SYNTAX_PLAN.relative_to(ROOT)} must be present",
     )
     require(
         UTF16_SECRET_SCAN_PLAN in plans,

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -157,6 +157,36 @@ class TrackedFileBoundaryTests(unittest.TestCase):
             with self.assertRaisesRegex(AssertionError, "worktree.txt.*Twilio auth token"):
                 CONTRACTS.check_tracked_secret_patterns()
 
+    def test_rejects_shell_declaration_secret_assignments(self):
+        fixtures = {
+            "local-token.sh": "local TWILIO_AUTH_TOKEN=" + "0123456789abcdef" * 2,
+            "readonly-token.sh": "readonly TWILIO_AUTH_TOKEN=" + "0123456789abcdef" * 2,
+            "readonly-options-phone.sh": "readonly -- TWILIO_FROM=+15559876543",
+            "declare-phone.sh": "declare -x TWILIO_TO=+15551234567",
+            "declare-options-token.sh": "declare -x -r TWILIO_AUTH_TOKEN=" + "0123456789abcdef" * 2,
+            "typeset-phone.sh": "typeset -xr TWILIO_FROM=+15557654321",
+        }
+        for relative_path, fixture in fixtures.items():
+            with self.subTest(relative_path=relative_path), temporary_repository() as repository:
+                (repository / relative_path).write_text(fixture + "\n", encoding="utf-8")
+                git(repository, "add", relative_path)
+
+                with self.assertRaisesRegex(AssertionError, "Twilio auth token|Twilio phone"):
+                    CONTRACTS.check_tracked_secret_patterns()
+
+    def test_rejects_powershell_environment_secret_assignments(self):
+        fixtures = {
+            "token.ps1": '$env:TWILIO_AUTH_TOKEN = "' + "0123456789abcdef" * 2 + '"',
+            "phone.ps1": '$env:TWILIO_FROM = "+15551234567"',
+        }
+        for relative_path, fixture in fixtures.items():
+            with self.subTest(relative_path=relative_path), temporary_repository() as repository:
+                (repository / relative_path).write_text(fixture + "\n", encoding="utf-8")
+                git(repository, "add", relative_path)
+
+                with self.assertRaisesRegex(AssertionError, "Twilio auth token|Twilio phone"):
+                    CONTRACTS.check_tracked_secret_patterns()
+
 
 class PlaceholderScopeTests(unittest.TestCase):
     def test_allows_reviewed_make_wrapper(self):


### PR DESCRIPTION
## Summary
- detect Twilio tokens and phone numbers assigned through `local`, `readonly`, `declare`, and `typeset`
- detect case-insensitive PowerShell `$env:` assignments

## Baseline
- tracked secret scanning did not cover shell declaration prefixes, repeated shell options, or PowerShell environment assignments

## Improvements
- support bounded repeated shell options such as `-x -r`, `-xr`, and `--`
- preserve staged/worktree, encoding, size, symlink, and placeholder boundaries

## Validation
- red-first shell, PowerShell, and repeated-option regressions passed
- canonical Make checks passed under `C` and `C.UTF-8` with 21 tests
- all six public targets passed externally through the absolute Makefile path
- prefix-removal mutations, Python compilation, shell syntax, regex probes, and `git diff --check` passed

## Risk
- the repository remains dependency-free and performs no live Twilio call; pattern-based scanning cannot prove all future secret formats are covered

## Follow-Ups
- extend declaration parsing tests when new supported shell or PowerShell assignment forms are introduced
