### PR TITLE
Scan env command secret assignments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@
 - Keep local Twilio credentials and debug output out of git; `.env` files and `*.log` and `*.har` files are intentionally ignored. Common local OS and IDE metadata files are ignored as well.
 - Tracked-secret assignment detection covers bare, quoted, `export`, `local`,
   `readonly`, `declare`, `typeset`, and PowerShell `$env:` forms for Twilio
-  token and phone placeholders.
+  token and phone placeholders, plus `env` command assignments with options.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-twilio-test-baseline.md` for the canonical placeholder contract baseline.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,48 @@
 # Changes
 
+## 2026-06-26 16:56 PDT - P1 - Scan `env` command secret assignments
+
+### Summary
+Closed a tracked-secret scanner bypass for Twilio tokens and phone numbers
+assigned through the shell `env` command.
+
+### Work completed
+- Added red-first token and phone fixtures for `env` assignments.
+- Recognized `env`, `/usr/bin/env`, no-operand options, attached or separated
+  option operands, and `--` before the existing exact Twilio patterns.
+- Documented the scanner boundary without introducing Twilio runtime behavior.
+
+### Threads
+- Started: none; the bounded scanner change was completed directly.
+- Continued: repository-wide tracked-secret hardening.
+- Stopped: none.
+
+### Files changed
+- `scripts/check_repository_contracts.py` — scans `env` assignment prefixes.
+- `tests/test_repository_contracts.py` — proves token and phone bypasses fail.
+- `SECURITY.md`, `AGENTS.md`, and the completed plan — document the boundary.
+
+### Validation
+- Focused unit regression — failed twice before implementation for the expected
+  missing token and phone detections.
+- Manual exact-head review found `-u NAME` and `--chdir DIR` bypasses in the
+  first patch; both new regressions failed before the explicit option grammar.
+- `./scripts/run-make.sh check` — passed 22 unit tests, repository contracts,
+  greeting runtime regressions, and Make authority tests.
+- External-path `make -C /tmp -f <checkout>/Makefile check` — passed.
+- Python compilation and `git diff --check` — passed.
+- Hosted exact-head checks remain next.
+
+### Bugs / findings
+- P1 security: tracked shell files could hide populated protected variables
+  behind `env` command invocation syntax.
+
+### Blockers
+- None.
+
+### Next action
+- Run local and hosted exact-head validation, review, and merge the focused PR.
+
 ## 2026-06-26 02:42 PDT - P2 - Scan shell declaration secrets
 
 ### Summary

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,7 @@ Helpful reports include:
   UTF-32 little-endian and big-endian text for real-looking Twilio SIDs,
   populated token/phone assignments, and private-key blocks while leaving
   unrecognized binary data uninterpreted. Assignment scanning includes common
-  shell declarations and PowerShell `$env:` syntax in addition to dotenv,
+  shell declarations, `env` command assignments, and PowerShell `$env:` syntax in addition to dotenv,
   YAML, and JSON forms.
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - Use `./scripts/run-make.sh check` for repository verification. The wrapper

--- a/docs/plans/2026-06-26-env-command-secret-assignments.md
+++ b/docs/plans/2026-06-26-env-command-secret-assignments.md
@@ -1,0 +1,25 @@
+# Scan `env` command secret assignments
+
+Status: Completed
+
+## Problem
+
+The tracked-secret scanner recognized bare assignments, shell declarations,
+PowerShell environment assignments, dotenv, YAML, and JSON, but not the common
+shell form `env TWILIO_AUTH_TOKEN=... command`. Adding `env` options such as
+`-i --` also bypassed detection.
+
+## Fix
+
+- Recognize `env` and `/usr/bin/env` before protected Twilio assignments.
+- Accept no-operand options, attached or separated operands for `-u`, `-C`,
+  `-S`, and their long forms, plus the `--` option terminator.
+- Preserve the existing exact variable names and real-looking token or phone
+  value requirements to avoid broad secret-name matching.
+- Add red-first fixtures for token and phone assignments.
+
+## Validation
+
+- Run the focused unit regression.
+- Run `make check` from the checkout and an external path.
+- Require hosted Python-matrix and CodeQL evidence before merge.

--- a/scripts/check_repository_contracts.py
+++ b/scripts/check_repository_contracts.py
@@ -85,7 +85,8 @@ RUNTIME_SUFFIXES = {
 }
 
 SECRET_ASSIGNMENT_PREFIX = (
-    r'''(?:(?:export|local|readonly|declare|typeset)'''
+    r'''(?:(?:env|/usr/bin/env)(?:[ \t]+(?:--|-[iv]|-(?:u|C|S)(?:[^ \t]+|[ \t]+[^ \t]+)|--(?:ignore-environment|debug|null)|--(?:unset|chdir|split-string|argv0)(?:=[^ \t]+|[ \t]+[^ \t]+)))*[ \t]+'''
+    r'''|(?:export|local|readonly|declare|typeset)'''
     r'''(?:[ \t]+(?:[-+][A-Za-z]+|--))*[ \t]+'''
     r'''|\$env:)?'''
 )

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -174,6 +174,23 @@ class TrackedFileBoundaryTests(unittest.TestCase):
                 with self.assertRaisesRegex(AssertionError, "Twilio auth token|Twilio phone"):
                     CONTRACTS.check_tracked_secret_patterns()
 
+    def test_rejects_env_command_secret_assignments(self):
+        fixtures = {
+            "env-token.sh": "env TWILIO_AUTH_TOKEN=" + "0123456789abcdef" * 2 + " command",
+            "env-options-phone.sh": "env -i -- TWILIO_FROM=+15551234567 command",
+            "absolute-env-token.sh": "/usr/bin/env TWILIO_AUTH_TOKEN=" + "fedcba9876543210" * 2 + " command",
+            "env-long-option-phone.sh": "env --ignore-environment TWILIO_TO=+15557654321 command",
+            "env-short-option-operand-token.sh": "env -u OLD_TOKEN TWILIO_AUTH_TOKEN=" + "0011223344556677" * 2 + " command",
+            "env-long-option-operand-phone.sh": "/usr/bin/env --chdir /tmp TWILIO_FROM=+15559876543 command",
+        }
+        for relative_path, fixture in fixtures.items():
+            with self.subTest(relative_path=relative_path), temporary_repository() as repository:
+                (repository / relative_path).write_text(fixture + "\n", encoding="utf-8")
+                git(repository, "add", relative_path)
+
+                with self.assertRaisesRegex(AssertionError, "Twilio auth token|Twilio phone"):
+                    CONTRACTS.check_tracked_secret_patterns()
+
     def test_rejects_powershell_environment_secret_assignments(self):
         fixtures = {
             "token.ps1": '$env:TWILIO_AUTH_TOKEN = "' + "0123456789abcdef" * 2 + '"',


### PR DESCRIPTION
## Summary
- detect Twilio token and phone assignments passed through `env`
- cover short options, long options, `--`, and `/usr/bin/env`
- preserve the runtime-free exact-variable and real-looking-value boundary

## Validation
- red-first focused regression: both original fixtures bypassed before the fix
- `./scripts/run-make.sh check` (22 unit tests plus repository/greeting/Make contracts)
- external-path `make -C /tmp -f <checkout>/Makefile check`
- Python compilation and `git diff --check`
